### PR TITLE
Add Step to Set LIBVIRT_DEFAULT_URI in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,13 @@ specified otherwise.
 
         setup-network
 
+1. [HOST] Export LIBVIRT_DEFAULT_URI to prevent undercloud-live using 
+   qemu:///system.  Check that the default libvirt connection for your user is 
+   qemu:///system. If it is not, set an environment variable to configure the 
+   connection. 
+
+        export LIBVIRT_DEFAULT_URI=${LIBVIRT_DEFAULT_URI:-"qemu:///system"} 
+
 1. [HOST] Create the baremetal nodes.  Specify the path to your undercloud-live 
    checkout as needed.  Save the output of this command, you will need it later.
 


### PR DESCRIPTION
Added step to set LIBVIRT_DEFAULT_URI.  Needed for running  undercloud-live/bin/nodes.sh
