### PR TITLE
Add Step: Ensure that openvswitch is started before setup_network

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,10 @@ specified otherwise.
         export NODE_DISK=20 
         export NODE_ARCH=amd64
 
+1. [HOST] Ensure that openvswitch is started
+
+        sudo service openvswitch start
+
 1. [HOST] Setup the brbm openvswitch bridge and libvirt network.
 
         setup-network


### PR DESCRIPTION
If openvswitch is not started when setup_network is run it fails with exception.  This patch adds a step in the Readme to ensure it's started.
