### PR TITLE
Cinder volume node util scripts

### DIFF
--- a/bin/cinder-node-prep.sh
+++ b/bin/cinder-node-prep.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -eux
+
+sudo -i /opt/stack/tripleo-incubator/scripts/create-nodes 1 2048 20 amd64 1
+export MACS=$(/opt/stack/tripleo-incubator/scripts/get-vm-mac baremetal_2)
+TRIPLEO_ROOT=/opt/stack/images /opt/stack/tripleo-incubator/scripts/setup-baremetal 1 2048 20 amd64 "$MACS" undercloud-live

--- a/bin/clean-baremetal.sh
+++ b/bin/clean-baremetal.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -eux
+
+for ID in $(nova baremetal-node-list | grep "\(undercloud-live\)" | awk '{print $2}'); do
+	nova baremetal-node-delete $ID
+done
+
+echo "Done cleaning baremetal nodes"

--- a/bin/clean-images.sh
+++ b/bin/clean-images.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -eux
+
+IMAGES_DIR=/opt/stack/images
+
+for ID in $(glance image-list | grep "\(bm-deploy\|overcloud-compute\|overcloud-control\)" | awk '{print $2}'); do
+	glance image-delete $ID
+done
+
+rm -rf $IMAGES_DIR/overcloud-control.qcow2*
+rm -rf $IMAGES_DIR/overcloud-compute.qcow2*
+
+echo "Done cleaning images"

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -71,7 +71,7 @@ git fetch https://review.openstack.org/openstack/diskimage-builder refs/changes/
 rm elements/base/finalise.d/52-force-text-mode-console
 popd
 
-git clone https://github.com/agroup/tripleo-puppet-elements
+git clone https://github.com/rbrady/tripleo-puppet-elements
 
 git clone https://github.com/openstack/tripleo-heat-templates.git
 pushd tripleo-heat-templates

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -71,7 +71,7 @@ git fetch https://review.openstack.org/openstack/diskimage-builder refs/changes/
 rm elements/base/finalise.d/52-force-text-mode-console
 popd
 
-git clone https://github.com/rbrady/tripleo-puppet-elements
+git clone --branch=cinder https://github.com/rbrady/tripleo-puppet-elements
 
 git clone https://github.com/openstack/tripleo-heat-templates.git
 pushd tripleo-heat-templates


### PR DESCRIPTION
I'm using these scripts to help me quickly wipe the slate clean when making changes to images and testing them by building new images and creating a new heat stack.  I forked the repo so I'd have a place to store these for my work but thought the clean-images and clean-baremetal might be useful in the agroup repo as well.
